### PR TITLE
Add opt-in RouteContract account-insert pilot

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -67,6 +67,73 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>routecontract-pilot</id>
+      <activation>
+        <property>
+          <name>routecontractPilot</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>routecontract-v0.1.0-local</id>
+          <url>file://${routecontract.repository}</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <dependencies>
+        <dependency>
+          <groupId>io.github.ym0506.routecontract</groupId>
+          <artifactId>routecontract-shardingsphere-5.5</artifactId>
+          <version>0.1.0</version>
+          <!--
+            Compile scope is intentional only inside this opt-in profile so the provider is available
+            to the Quarkus application runtime. The sealed run proves discovery and callbacks with
+            this scope; it does not compare test scope or seal the exact discovery time.
+          -->
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-routecontract-pilot-test-source</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src/routeContractPilot/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <routecontract.projectDir>${project.basedir}</routecontract.projectDir>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <!--
   <profiles>
     <profile>

--- a/integration-tests/src/routeContractPilot/java/io/quarkiverse/shardingsphere/jdbc/it/RouteContractInsertPilotTest.java
+++ b/integration-tests/src/routeContractPilot/java/io/quarkiverse/shardingsphere/jdbc/it/RouteContractInsertPilotTest.java
@@ -1,0 +1,86 @@
+package io.quarkiverse.shardingsphere.jdbc.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.ym0506.routecontract.RouteAssertions;
+import io.github.ym0506.routecontract.RouteContract;
+import io.github.ym0506.routecontract.RouteSnapshot;
+import io.github.ym0506.routecontract.manifest.DataSourceAliases;
+import io.github.ym0506.routecontract.manifest.ManifestAssertions;
+import io.github.ym0506.routecontract.manifest.ManifestPolicy;
+import io.github.ym0506.routecontract.manifest.ManifestStore;
+import io.github.ym0506.routecontract.manifest.ManifestVerifier;
+import io.github.ym0506.routecontract.manifest.ObservedExecutionManifest;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(H2DatabaseTestResource.class)
+public class RouteContractInsertPilotTest {
+
+    @Inject
+    ShardingTablesResource resource;
+
+    @Test
+    public void keepsTheApprovedInsertStructure() throws Exception {
+        assertEquals(0, resource.count("ds_0", "t_account_0"));
+        assertEquals(0, resource.count("ds_0", "t_account_1"));
+        assertEquals(0, resource.count("ds_1", "t_account_0"));
+        assertEquals(0, resource.count("ds_1", "t_account_1"));
+
+        Account account = new Account();
+        account.setAccount_id(1);
+        account.setUser_id(1);
+        account.setStatus("true");
+
+        RouteSnapshot snapshot = RouteContract.capture("accounts.insert", () -> resource.createAccount(account));
+
+        // Keep the representative test's complete business result: only ds_1.t_account_1 changes.
+        assertEquals(0, resource.count("ds_0", "t_account_0"));
+        assertEquals(0, resource.count("ds_0", "t_account_1"));
+        assertEquals(0, resource.count("ds_1", "t_account_0"));
+        assertEquals(1, resource.count("ds_1", "t_account_1"));
+        RouteAssertions.assertThat(snapshot)
+                .hasCompleteCapture()
+                .hasNoReportedExecutionFailures()
+                .hasExactlyObservedPhysicalAttempts(1)
+                .observesExactlyDataSourceNames("ds_1");
+
+        int proposedMaxAttempts = 1;
+        int proposedMaxDataSources = 1;
+        ManifestPolicy policy = ManifestPolicy.strict(proposedMaxAttempts, proposedMaxDataSources);
+        DataSourceAliases aliases = DataSourceAliases.of(Map.of(
+                "ds_0", "account-shard-a",
+                "ds_1", "account-shard-b"));
+        ObservedExecutionManifest candidate = ObservedExecutionManifest.from(snapshot, aliases, policy);
+
+        Path projectDir = Path.of(System.getProperty("routecontract.projectDir")).toAbsolutePath().normalize();
+        Path approvedPath = projectDir.resolve(
+                "src/routeContractPilot/resources/route-contracts/accounts.insert.json");
+        Path candidatePath = projectDir.resolve("target/routecontract/accounts.insert.candidate.json");
+        ManifestStore store = new ManifestStore();
+        store.writeCandidate(approvedPath, candidatePath, candidate);
+
+        System.out.printf(
+                "ROUTECONTRACT_QUARKIVERSE_PILOT businessRows=0->1 attempts=%d dataSources=%s status=%s%n",
+                snapshot.observedPhysicalAttemptCount(), snapshot.observedDataSourceNames(), snapshot.status());
+
+        if (Files.notExists(approvedPath)) {
+            fail("No approved baseline. Review target/routecontract/accounts.insert.candidate.json "
+                    + "and copy its exact bytes only after human approval.");
+        }
+
+        ManifestAssertions.assertMatched(
+                new ManifestVerifier().verify(store.read(approvedPath), candidate));
+    }
+}


### PR DESCRIPTION
Context: #356

## Scope

This draft proposes an opt-in H2 execution-shape check for
`ShardingTablesResource#createAccount`. It keeps the exact two-file feasibility patch that was
linked from #356 and validated against base commit
`90e023ce45d58842011724d5b7e7e04d710eb459` with ShardingSphere-JDBC `5.5.3`.

It changes only:

1. `integration-tests/pom.xml`
2. `integration-tests/src/routeContractPilot/java/io/quarkiverse/shardingsphere/jdbc/it/RouteContractInsertPilotTest.java`

The `routecontract-pilot` Maven profile is disabled by default. When explicitly enabled, it adds
RouteContract `0.1.0` and the pilot test source. The dependency has compile scope only inside that
opt-in profile so the provider is available to the Quarkus application runtime. The normal build
remains RouteContract-free.

## Behavior and evidence boundary

The existing `ShardingTablesTest` sends an HTTP request, asserts HTTP 204, and then asserts the
final shard counts `0/0/0/1`. It does not assert that all four tables are empty before the request.

The pilot instead calls the injected CDI resource method directly inside the synchronous
`RouteContract.capture` boundary. It adds a pristine-start `0/0/0/0` assertion and preserves the
same final `0/0/0/1` counts. It intentionally omits the REST/HTTP handoff, and the existing
RestAssured test remains unchanged.

This is H2 feasibility evidence, not MySQL evidence. It does not claim a complete route plan,
transaction commit, general business success, production readiness, performance, security,
adoption, support, or endorsement.

## Important test-isolation limitation

The profile-on evidence below explicitly selected only `RouteContractInsertPilotTest` with
`-Dtest=RouteContractInsertPilotTest -Dsurefire.failIfNoSpecifiedTests=false`. The exact patch in
this draft adds the pilot source but does not narrow Surefire's default test selection.

Therefore an unfiltered `-DroutecontractPilot=true clean test` selects both
`ShardingTablesTest` and `RouteContractInsertPilotTest`. They share the H2 test resource and both
use `account_id=1`, so that unfiltered run conflicts and is not a passing merge-ready configuration.
This initial draft is for review of the operation and integration shape only; it must not be merged
as-is.

A profile-specific Surefire include can isolate the pilot naturally, but that changes the exact
patch invited in #356. I will propose that follow-up only after maintainer confirmation.

## Sealed local verification of the exact invited patch

For this exact patch and base commit:

- With the profile disabled, the full four-module `clean test` reactor passed its three existing
  tests with no failure, error, or skip. RouteContract was absent and no candidate was produced.
- With `-DroutecontractPilot=true` plus the explicit pilot-only `-Dtest` selection above, two clean
  runs executed only `RouteContractInsertPilotTest`. Both preserved the final shard counts,
  captured one `SQLExecutionHook`-reported physical JDBC attempt on `ds_1`, and produced
  byte-identical 679-byte candidates with SHA-256
  `60e94c17e2df96ff7f4769f33a6a7b4f3431b0cd0995d47906e6f63a3d1601e4`.
- Both pilot-only runs stopped only at the expected missing-human-approved-baseline gate.
- No claim is made that the unfiltered profile-on command passes for this exact patch.

The original feasibility patch, reproducer, receipt, and hashes are public here. This PR body is
the authoritative disclosure of the newly identified shared-H2 unfiltered profile-on limitation:

https://github.com/ym0506/routecontract/blob/713b5a03cf4930cc0996eeed96ec9b9bb0a6f7a0/docs/compatibility-pilots/quarkiverse-quarkus-shardingsphere-jdbc/README.md

## Maintainer decision remains separate

This draft deliberately contains no approved baseline. The generated candidate is not committed.
A repository maintainer still needs to decide whether this operation is representative, review the
synthetic aliases and budgets, decide whether the isolated follow-up is acceptable, and decide
whether the exact candidate bytes should ever become an approved baseline. Opening this draft does
not make or imply any of those decisions.
